### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/josephrodriguez/gotter/security/code-scanning/1](https://github.com/josephrodriguez/gotter/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block limiting the GITHUB_TOKEN access to the least privilege necessary. For the `build` job (lines 17–33), only `contents: read` is required, as the steps merely check out code, set up Go, and run tests/builds. Add a `permissions:` entry (with `contents: read`) directly under the `build:` key, on a new line before `runs-on:` (current line 18). No existing functionality will be changed, as this only governs the permissions granted to the GITHUB_TOKEN in this context. No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
